### PR TITLE
Improve Open Graph and Twitter preview images

### DIFF
--- a/site/includes/components/social-meta.njk
+++ b/site/includes/components/social-meta.njk
@@ -8,12 +8,12 @@
 <meta name="twitter:description" content="{% if meta_description %}{{ meta_description }}{% else %}{{ excerpt }}{% endif %}">
 <meta name="twitter:site" content="{{ site.author.handle }}">
 <meta name="twitter:creator" content="{{ site.author.handle }}">
-<meta name="twitter:image:src" content="{{ site.url }}{{ site.images.twitter }}">
+<meta name="twitter:image:src" content="{{ site.url }}{% if featured_image %}{{ featured_image }}{% else %}{{ site.images.og }}{% endif %}">
 
 {# Open Graph #}
 <meta name="og:title" content="{% if meta_title %}{{ meta_title }}{% else %}{{ title }}{% endif %} :: {{ site.name }}">
 <meta name="og:description" content="{% if meta_description %}{{ meta_description }}{% else %}{{ excerpt }}{% endif %}">
-<meta name="og:image" content="{{ site.url }}{{ site.images.og }}">
+<meta name="og:image" content="{{ site.url }}{% if featured_image %}{{ featured_image }}{% else %}{{ site.images.og }}{% endif %}">
 <meta name="og:url" content="{{ site.url }}{{ page.url }}">
 <meta name="og:site_name" content="{{ site.name }}">
 <meta name="og:locale" content="en">


### PR DESCRIPTION
If `featured_image` is defined, use that as the preview image. Else fallback to site image.