### PR TITLE
Set up development environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is **Dante** — Ted Goas's personal site/blog (www.tedgoas.com). It is a single
+static site built with **Eleventy (11ty)** + **Tailwind CSS** + **PostCSS**. There is no
+backend, database, API, or automated test suite. "Running the app" means building the static
+site and/or serving it locally.
+
+### Runtime
+- `.nvmrc` pins Node 14, but the code builds and runs cleanly on the VM's default Node 22.
+  No version switch is needed.
+- `package-lock.json` is gitignored, so `npm install` resolves against the `^` ranges in
+  `package.json`.
+
+### Commands (defined in `package.json`)
+- Dev server (live reload): `npm start` — serves on `http://localhost:8080` (Browsersync UI on
+  `http://localhost:3001`). Runs Eleventy `--serve` and PostCSS `--watch` in parallel.
+- Production build: `npm run build` — outputs to `dist/`.
+- No lint step and no tests exist in this repo.
+
+### Non-obvious notes
+- CSS is compiled by the standalone PostCSS command (`postcss:watch` / `postcss`), NOT by
+  Eleventy. `dist/assets/css/styles.css` only exists after that step runs, so a bare
+  `eleventy --serve` alone will not produce styles — always use the npm scripts (`npm start` /
+  `npm run build`) which run both.
+- `dist/` is fully regenerated on every run (`clean` runs first), so never edit files in `dist/`.
+- Content lives in `src/`: blog posts in `src/posts/`, portfolio in `src/work/`, site config/data
+  in `src/_data/`. Adding a Markdown file there is picked up automatically by live reload.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the local development environment for this Eleventy (11ty) + Tailwind + PostCSS static site. No application code changed — only adds `AGENTS.md` with durable Cursor Cloud setup notes.

## What was verified
- `npm install` — dependencies install cleanly (Node 22, `package-lock.json` is gitignored).
- `npm run build` — production build succeeds, outputs 71 pages + 383 copied files to `dist/`.
- `npm start` — dev server runs on `http://localhost:8080` with live reload (Eleventy `--serve` + PostCSS `--watch`).
- Hello-world task: added a temporary Markdown post in `src/posts/`, confirmed live reload rebuilt it and it rendered on the blog, then reverted it.

No lint step or automated tests exist in this repo.

## Environment
- Update script: `npm install`

## Demo
Homepage and blog rendering with full styling:

[Homepage rendered](https://cursor.com/agents/bc-374d3321-df0e-4ba5-9316-a5aa9812a07e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_rendered.webp)
[Blog list rendered](https://cursor.com/agents/bc-374d3321-df0e-4ba5-9316-a5aa9812a07e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_list_rendered.webp)

Live-reload content pipeline (add post -> appears -> renders):

[eleventy_live_reload_new_post.mp4](https://cursor.com/agents/bc-374d3321-df0e-4ba5-9316-a5aa9812a07e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feleventy_live_reload_new_post.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-374d3321-df0e-4ba5-9316-a5aa9812a07e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-374d3321-df0e-4ba5-9316-a5aa9812a07e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

