### PR TITLE
Add Cursor Cloud specific instructions to agents.md

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -225,6 +225,34 @@ For visual or UX work, read these before changing UI (Impeccable / agent design 
 
 `docs/visual-design-language.md` remains the guardrail doc for frozen homepage regions and theme experiments. Re-run `/impeccable document` after major palette or component changes.
 
+## Cursor Cloud specific instructions
+
+This repo is a single static site (Ted Goas's personal site) built with **Eleventy (11ty) v3**.
+There is **no backend, database, API, or automated test suite** — "running the app" means building
+the static site and/or serving it locally. Cloud agents build/run reliably here via the environment
+`update` script (`npm install`); this file is guidance only and does not provision the environment.
+
+### Runtime
+- Use the VM's default **Node 22**. There is no `.nvmrc` on this branch; Eleventy 3 requires
+  Node 18+, so do not downgrade to older Node.
+- `package-lock.json` is gitignored, so `npm install` resolves against the `^` ranges in
+  `package.json`.
+
+### Commands (defined in `package.json`)
+- Dev server (live reload): `npm start` — Eleventy's built-in dev server on
+  `http://localhost:8080`.
+- Production build: `npm run build` — outputs to `dist/`.
+- No lint step and no tests exist in this repo.
+
+### Non-obvious notes
+- **CSS is not compiled.** This branch uses custom CSS (no Tailwind, no PostCSS build step);
+  `src/assets/css/` and `themes/` are passthrough-copied by Eleventy (see `.eleventy.js`), so
+  `npm start` / `npm run build` alone produce the styled site. Edits to those CSS files are picked
+  up by the watcher.
+- `dist/` is fully regenerated on every run (`clean` runs first), so never edit files in `dist/`.
+- Content lives in `src/`: blog posts in `src/posts/`, work case studies in `src/work/`, site
+  config/data in `src/_data/`. Adding a Markdown file there is picked up automatically by live reload.
+
 ---
 
 *This document should be reviewed and updated as needed throughout the project.* 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to the existing `agents.md` on `2026-refresh`, so future cloud/mobile agents get accurate, durable setup guidance for this branch's stack. Documentation-only — no application/config code changed (`agents.md` +28 lines).

This supersedes PR #187 (which added an uppercase `AGENTS.md` off `main`). That file would have collided by case with this branch's lowercase `agents.md` and its content described the old Tailwind/PostCSS stack. PR #187 is being closed.

## Why against this branch
`2026-refresh` is becoming the source of truth and its stack differs from `main`:
- Eleventy **v3** (v3.1.6), not 0.12
- **No Tailwind, no PostCSS build step** — CSS is passthrough-copied
- No `.nvmrc` (runs on Node 22; Eleventy 3 needs Node 18+)
- `npm start` uses Eleventy's built-in dev server on `:8080`

## Verified on this branch
- `npm install` — 195 packages, clean.
- `npm run build` — Eleventy 3.1.6, wrote 80 files to `dist/`.
- `npm start` — dev server on `http://localhost:8080`; homepage, blog, and posts render with full styling.
- Hello-world: added a temp Markdown post to `src/posts/`, confirmed live reload rebuilt + rendered it, then reverted.

No lint step or automated tests exist in this repo.

## Note on cloud/mobile enablement
Cloud agents and the Cursor mobile app are enabled by the environment config (the per-repo `npm install` update script), not by this file — and they already work against any branch (including `2026-refresh`) without merging to `main`. This PR just makes agents behave correctly on this branch's stack.

## Demo
Homepage and blog rendering (2026 light redesign):

[Homepage rendered](https://cursor.com/agents/bc-374d3321-df0e-4ba5-9316-a5aa9812a07e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frefresh_homepage_rendered.webp)
[Blog list rendered](https://cursor.com/agents/bc-374d3321-df0e-4ba5-9316-a5aa9812a07e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frefresh_blog_rendered.webp)

Live-reload content pipeline (add post -> appears -> renders):

[refresh_eleventy_live_reload.mp4](https://cursor.com/agents/bc-374d3321-df0e-4ba5-9316-a5aa9812a07e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frefresh_eleventy_live_reload.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-374d3321-df0e-4ba5-9316-a5aa9812a07e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-374d3321-df0e-4ba5-9316-a5aa9812a07e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

