### PR TITLE
chore(agents): harden skills and add prototype-embed

### DIFF
--- a/.cursor/rules/dante-11ty.mdc
+++ b/.cursor/rules/dante-11ty.mdc
@@ -38,10 +38,11 @@ alwaysApply: true
 
 - Use 11ty layouts and includes for all repeated structure
 - Blog posts use Markdown with front matter
-- Case studies are HTML files with front matter — do not convert them to Markdown
+- Work case studies are Markdown in `src/work/` with front matter; gallery figures may include raw HTML blocks and Nunjucks shortcodes — keep them as Markdown (do not convert the page to a standalone HTML file)
 - Do not hardcode navigation links — derive them from collections or data files
 - **Work gallery video figures:** Use the `clickToPlayVideo` shortcode in Markdown work pages for poster + lazy MP4 + native controls after play. Full stack and UX rules live in **[AGENTS.md](AGENTS.md)** under *Work gallery: video figures (click-to-play)*.
-- **Work gallery multi-image figures:** Layout modifiers, atmosphere backdrops, and HTML templates — **[`.cursor/skills/work-gallery-figures/SKILL.md`](.cursor/skills/work-gallery-figures/SKILL.md)** and [AGENTS.md](AGENTS.md) (*Work gallery: multi-image layouts*).
+- **Work gallery interactive prototypes:** Use the `prototypeEmbed` shortcode and keep bundles under `src/assets/work/prototypes/{slug}/` — **[`.cursor/skills/prototype-embed/SKILL.md`](.cursor/skills/prototype-embed/SKILL.md)** and [AGENTS.md](AGENTS.md) (*Work gallery: interactive prototypes*).
+- **Work gallery multi-image figures:** Layout modifiers and HTML templates — **[`.cursor/skills/work-gallery-figures/SKILL.md`](.cursor/skills/work-gallery-figures/SKILL.md)** and [AGENTS.md](AGENTS.md) (*Work gallery: multi-image layouts*). Atmosphere backdrops are legacy (visually removed); do not rely on them for new visual design.
 
 ## Theming
 

--- a/.cursor/skills/commit/SKILL.md
+++ b/.cursor/skills/commit/SKILL.md
@@ -33,19 +33,24 @@ description: >-
 - `src/posts/`, work entries → `content` or `feat`
 - `src/assets/css/`, themes → `style` or `perf`
 - `.eleventy.js`, `_data`, layouts, includes → `chore` or `fix`
+- `.cursor/`, `AGENTS.md`, agent skills → `chore`
 
 ## Workflow
 
-1. **Review** — `git status`; `git diff` (or scoped diff) so the message matches what will be committed.
-2. **Stage** — `git add <paths>` or `git add -p`; avoid unrelated files.
-3. **Commit** — `git commit -m "type(scope): description"`.
+1. **Review** — `git status`; `git diff` (staged and unstaged) so the message matches what will be committed.
+2. **Dirty tree** — List every modified/untracked path. Separate **this task** from leftovers (other agents, WIP, unrelated experiments).
+3. **Stage selectively** — `git add <paths>` or `git add -p` for **only** the task paths. Never `git add -A` / `git add .` when unrelated changes exist.
+4. **Refuse scooping** — If unrelated dirty files are present, leave them unstaged. If the user asked to “commit everything,” confirm first. If unsure which paths belong to the task, ask before staging.
+5. **Commit** — `git commit -m "type(scope): description"`.
 
 Do **not** run `git push` here. If the user wants to publish, use the **push** skill after committing.
 
 ## Safety
 
-- Commit only when the user asked to commit (see project `agents.md`).
-- Do not commit secrets or accidental unrelated changes.
+- Commit only when the user asked to commit (see project `AGENTS.md`).
+- Do not commit secrets, `.env`, or accidental unrelated changes.
+- Do not commit `.impeccable/live/` or `.impeccable/critique/` (gitignored ephemeral output).
+- After commit, run `git status` and confirm leftovers (if any) remain unstaged as expected.
 
 ## Examples
 
@@ -53,3 +58,4 @@ Do **not** run `git push` here. If the user wants to publish, use the **push** s
 - `content(blog): publish post on interviewing designers`
 - `style(css): tighten focus ring on skip link`
 - `chore(11ty): add passthrough copy for assets`
+- `chore(agents): add prototype-embed skill`

--- a/.cursor/skills/component-pattern/SKILL.md
+++ b/.cursor/skills/component-pattern/SKILL.md
@@ -1,28 +1,29 @@
 ---
 name: component-pattern
 description: >-
-  11ty component structure — pair Nunjucks/HTML partials in _includes/components/
-  with scoped CSS in css/components/ using BEM and theme tokens.
+  11ty component structure — Nunjucks/HTML partials in _includes/components/
+  with BEM classes and theme tokens; styles live in the main stylesheet (or
+  themes/), not a separate css/components/ tree.
 ---
 
-# Cursor Skills
+# Component pattern
 
-## Skill: Component Pattern
+11ty UI pieces are a Nunjucks or HTML partial in [`src/_includes/components/`](../../../src/_includes/components/) plus styles that use BEM and theme tokens. Most site CSS lives in [`src/assets/css/styles.css`](../../../src/assets/css/styles.css); tokens and theme values live in [`themes/`](../../../themes/). Do **not** add a parallel `css/components/` folder unless the user explicitly asks for that structure.
 
-11ty components consist of a Nunjucks or HTML partial in `_includes/components/` paired with a scoped CSS file in `css/components/`.
-
-**Partial**:
+## Partial
 
 - Uses BEM class names rooted at the component name
 - Accepts data via Nunjucks macro parameters or 11ty page data
 - No inline styles
 
-**CSS**:
+## CSS
 
-- Scoped to the component's root BEM class
-- References only CSS custom properties for all values
-- Linked in the base layout or included via a CSS entry point
+- Scoped to the component’s root BEM class (or a documented gallery modifier)
+- References only CSS custom properties for colors, spacing, type, and radii
+- Linked from the base layout (site stylesheet) — no per-component CSS entry point today
 
-**Exception — click-to-play video (work gallery):** The partial lives in `_includes/components/click-to-play-video.njk`, but styles are in the main stylesheet ([`src/assets/css/styles.css`](../../../src/assets/css/styles.css)) next to other `.work-gallery` rules, and behavior JS is bundled only on the work layout. See **[AGENTS.md](../../../AGENTS.md)** (*Work gallery: video figures*) for the full file map and authoring shortcode.
+## Documented exceptions
 
-**Exception — multi-image gallery figures:** Layout and atmosphere backdrops are BEM classes in the same stylesheet, authored as HTML in case studies. See **[`.cursor/skills/work-gallery-figures/SKILL.md`](../work-gallery-figures/SKILL.md)** and AGENTS.md (*Work gallery: multi-image layouts*).
+- **Click-to-play video (work gallery):** Partial in `_includes/components/click-to-play-video.njk`; styles next to other `.work-gallery` rules in `styles.css`; JS only on the work layout. See **[AGENTS.md](../../../AGENTS.md)** (*Work gallery: video figures*).
+- **Prototype embeds:** Partial + shortcode + work-layout JS — **[`.cursor/skills/prototype-embed/SKILL.md`](../prototype-embed/SKILL.md)**.
+- **Multi-image gallery figures:** BEM layout classes in `styles.css`, authored as HTML in Markdown case studies. See **[`.cursor/skills/work-gallery-figures/SKILL.md`](../work-gallery-figures/SKILL.md)** and AGENTS.md (*Work gallery: multi-image layouts*).

--- a/.cursor/skills/prototype-embed/SKILL.md
+++ b/.cursor/skills/prototype-embed/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: prototype-embed
+description: >-
+  Work gallery interactive prototypes — sync static bundles into
+  src/assets/work/prototypes/{slug}/, wire prototypeEmbed shortcode, scroll-gated
+  iframe activation, autostart demos, and Replay postMessage. Use when adding,
+  updating, or debugging Dialpad prototype embeds on case study pages.
+---
+
+# Prototype embed
+
+Use when a work case study figure should show a **live interactive prototype** (iframe) instead of a click-to-play video. Bundles stay in-repo under [`src/assets/work/prototypes/{slug}/`](../../../src/assets/work/prototypes/) so prototype CSS/JS never collides with the main site and Netlify does not depend on remote github.io iframes.
+
+**Canonical detail:** [AGENTS.md](../../../AGENTS.md) (*Work gallery: interactive prototypes*).  
+**Host page script:** work layout only — [`src/_includes/layouts/work.njk`](../../../src/_includes/layouts/work.njk) `footerScripts`.
+
+## Valid slugs
+
+| Slug | Poster (auto) |
+|------|----------------|
+| `analytics-gpt` | `/assets/work/dialpad-team-analyticsgpt.svg` |
+| `launchpad` | `/assets/work/dialpad-team-launchpad.svg` |
+| `ai-chatbot` | `/assets/work/dialpad-team-chatbot.svg` |
+| `scorecards` | `/assets/work/dialpad-ic-scorecards.svg` |
+
+Adding a new slug requires updating `VALID_SLUGS` and `POSTER_BY_SLUG` in [`lib/shortcodes/prototypeEmbed.js`](../../../lib/shortcodes/prototypeEmbed.js) (and committing the new bundle). Ask before inventing a fifth slug.
+
+## Authoring (Markdown work pages)
+
+```njk
+{% prototypeEmbed "analytics-gpt", "Dialpad AnalyticsGPT design.", 1440, 900 %}
+{% prototypeEmbed "ai-chatbot", "Dialpad chatbot design.", 384, 600, "/assets/work/dialpad-team-chatbot-bg.jpg" %}
+```
+
+Args: `slug`, `title` (iframe `title`), `width`, `height`, optional `background` image path (same wallpaper pattern as click-to-play). Do not pass an empty string before a background path — Eleventy drops empty shortcode args.
+
+Wrap the figure with `work-gallery__item--media-native` when the embed should sit at native width (see work-gallery-figures).
+
+## Update / sync workflow
+
+1. Rebuild the embed bundle externally (or from a local [`.sizzle-reel/`](../../../.sizzle-reel/) checkout — gitignored, not a submodule).
+2. Copy output into `src/assets/work/prototypes/{slug}/` (`index.html` + hashed JS/CSS under `assets/`). Remove stale hashed files from a previous build for that slug.
+3. Keep everything in Dante — no remote iframe `src` to github.io or other hosts.
+4. Commit only the changed slug folder(s) plus any shortcode/poster wiring (see **commit** skill dirty-tree rules).
+
+## Host-page behavior (do not reimplement ad hoc)
+
+| Behavior | Detail |
+|----------|--------|
+| Scroll gate | ~35% visible, then **1s** delay before `data-src` → `src?autostart=1` |
+| Cancel | Scrolling away before the delay clears the timer |
+| Replay | Iframe posts `{ type: 'dante-prototype-demo-complete' }` → centered Replay button; click sends `{ type: 'dante-prototype-replay' }` via `postMessage` (no iframe reload) |
+| Reduced motion | Skip activation JS; static poster + link to open prototype in a new tab |
+
+Implementation map: shortcode, Nunjucks partial, markdown preprocessor, [`src/assets/js/prototype-embed.js`](../../../src/assets/js/prototype-embed.js), styles under `.prototype-embed` in `styles.css` — see AGENTS.md table.
+
+## In-bundle demo conventions
+
+When editing prototype bundle JS (cursor autoplay, multi-screen sequences):
+
+- Honor `?autostart=1` (and ignore autoplay under reduced motion inside the iframe when feasible).
+- On demo finish, `parent.postMessage({ type: 'dante-prototype-demo-complete' }, '*')`.
+- Listen for `message` with `data.type === 'dante-prototype-replay'` and restart the sequence without a full navigation.
+- Prefer scripted cursor: hover → click → pause → next screen; keep timing calm, not noisy.
+
+## Checklist
+
+1. Valid slug + matching poster path in shortcode map.
+2. Bundle committed under `src/assets/work/prototypes/{slug}/`.
+3. Shortcode on the Markdown work page with correct width/height (and background if needed).
+4. Build; open `/work/<case-study>/`; scroll into view; confirm autostart, demo complete → Replay, reduced-motion poster path.
+5. Stage only prototype-related paths when committing.
+
+## Do not
+
+- Point the iframe at a remote demo host.
+- Load `prototype-embed.js` on the default (non-work) layout for a one-off figure.
+- Add npm packages for embed chrome — vanilla JS + existing CSS tokens only.
+- Scoop unrelated dirty-tree files into the same commit.

--- a/.cursor/skills/work-gallery-figures/SKILL.md
+++ b/.cursor/skills/work-gallery-figures/SKILL.md
@@ -2,8 +2,8 @@
 name: work-gallery-figures
 description: >-
   Work case study gallery figures — multi-image layouts (hero-secondary, email-duo,
-  sidebar-quad, integrations-stack, experiment-grid), CSS atmosphere backdrops, and palette modifiers.
-  Use when adding, editing, or styling work gallery figures in case study HTML.
+  sidebar-quad, integrations-stack, experiment-grid) and border/radius modifiers.
+  Use when adding, editing, or styling work gallery figures in case study Markdown.
 ---
 
 # Work gallery figures
@@ -13,7 +13,8 @@ Case studies use a `<section class="work-gallery">` of `<figure class="work-gall
 **Canonical reference:** [reference.md](reference.md) (copy-paste HTML templates).  
 **Repo rules:** [AGENTS.md](../../../AGENTS.md) (*Work gallery* sections).  
 **Styles:** [`src/assets/css/styles.css`](../../../src/assets/css/styles.css) (search `Reusable figure pattern`).  
-**Video figures:** use the `clickToPlayVideo` shortcode — see AGENTS.md, not this skill.
+**Video figures:** use the `clickToPlayVideo` shortcode — see AGENTS.md, not this skill.  
+**Interactive prototypes:** use **[`.cursor/skills/prototype-embed/SKILL.md`](../prototype-embed/SKILL.md)**.
 
 ## Quick picker
 
@@ -26,38 +27,31 @@ Case studies use a `<section class="work-gallery">` of `<figure class="work-gall
 | Four panels in two columns | `work-gallery__item--sidebar-quad` | `work-gallery__media--sidebar-quad` | `.work-gallery__sidebar-quad` + `__col` |
 | Two overlapping cards | `work-gallery__item--integrations-stack` | `work-gallery__media--integrations-stack` | `__integrations-stack__stage` + `__back` / `__front` |
 | Tone hero + 3-column sidebar cards | `work-gallery__item--experiment-grid` | `work-gallery__media--experiment-grid` | `__experiment-grid__tone` + `__sidebar` + `__col` |
-| Large native asset (e.g. MP4 frame) | `work-gallery__item--media-native` | per click-to-play or img | — |
+| Large native asset (e.g. MP4 frame) | `work-gallery__item--media-native` | per click-to-play, prototype embed, or img | — |
 | No hairline border (keep 8px radius) | `work-gallery__item--borderless` | or `work-gallery__media--borderless` on one img | Dark / wallpaper exceptions |
 | No border, no radius | `work-gallery__item--plain` | — | Floating logos |
 
-## Atmosphere backdrop (CSS only)
+## Atmosphere backdrops (legacy)
 
-Add on the **media** `div` when the frame should have a gradient “stage” (not on single `<img>` figures):
+Atmosphere radial-gradient “stages” are **visually removed** in the light redesign (backdrop `display: none`; gradient palettes deleted from CSS). Foreground media sits on a plain light card surface.
 
-1. `work-gallery__media--has-backdrop`
-2. `work-gallery__media--backdrop-atmosphere`
-3. One palette: `work-gallery__media--atmosphere-warm-light` | `…-amber-dusk` | `…-cool-dark`
-4. First child: `<div class="work-gallery__backdrop" aria-hidden="true"></div>`
+- The `workGalleryAtmosphere` transform may still inject `.work-gallery__backdrop` markup and `--atmosphere-*` classes for stable figure indexing — treat that as legacy plumbing.
+- **Do not** author new figures for the visual effect of atmosphere palettes. Prefer layout modifiers + border/radius exceptions above.
+- Full legacy reference (if you must touch the transform): [AGENTS.md](../../../AGENTS.md) (*Work gallery: multi-image figure backdrops*).
 
-**Auto-assign:** Omit the four classes above; [`workGalleryAtmosphere`](../../../lib/transforms/workGalleryAtmosphere.js) injects them on `hero-secondary`, `sidebar-quad`, `integrations-stack`, and `experiment-grid` media blocks (stable hash per page slug + figure order).
-
-**Manual palette:** Add all backdrop classes + backdrop `div` yourself; transform skips that block but still counts its index so sibling auto figures keep the same palette slot.
-
-**Padding:** Multi-image frames use `--work-gallery-atmosphere-frame-padding` on top/left/right. `hero-secondary` (with or without backdrop) uses **flush bottom** — images align to the frame’s bottom edge (`align-items: end` + zero bottom padding).
-
-**Width:** Backdrop frames use `width: fit-content; max-width: 100%; margin-inline: auto` so the stage hugs content (not full 90rem bleed).
+**Padding:** Multi-image frames use top/left/right padding tokens. `hero-secondary` uses **flush bottom** — images align to the frame’s bottom edge (`align-items: end` + zero bottom padding).
 
 ## Checklist for a new multi-image figure
 
 1. Pick layout row from the table; copy the matching template from [reference.md](reference.md).
 2. Set `width` / `height` on images; descriptive `alt`; `loading="lazy"`.
 3. Add `aria-label` on the media `div` when multiple images need one summary.
-4. Choose auto atmosphere or manual palette (see above).
-5. Build and check `/work/<slug>/` — spacing, bottom flush on hero-secondary, backdrop width.
+4. Do not add atmosphere classes for new visual design (see legacy note above).
+5. Build and check `/work/<slug>/` — spacing, bottom flush on hero-secondary, borders/radius.
 
 ## Do not
 
-- Convert case studies to Markdown for gallery HTML.
+- Convert case study pages from Markdown to standalone HTML files just to host gallery HTML (HTML blocks inside Markdown are fine).
 - Add npm packages or inline styles for gallery layout.
-- Hardcode colors — palettes use `--work-gallery-atmosphere-*` and theme tokens.
-- Partial manual backdrop on one figure without understanding index order (fixed in transform; manual siblings still need explicit palette if you override any figure on the page).
+- Hardcode colors — use theme tokens.
+- Rely on atmosphere backdrops for new visuals.

--- a/agents.md
+++ b/agents.md
@@ -135,6 +135,8 @@ Args: `slug`, `title` (iframe `title`), `width`, `height`, optional `background`
 2. Copy the output into `src/assets/work/prototypes/{slug}/` for each changed slug
 3. Commit the updated static files in Dante
 
+Agent skill (workflow + demo/`postMessage` conventions): [`.cursor/skills/prototype-embed/SKILL.md`](.cursor/skills/prototype-embed/SKILL.md).
+
 **UX notes:** Each figure shows a static poster until it scrolls into view (~35% visible), then waits 1 second before loading the iframe (`data-src` → `src?autostart=1`). Scrolling away before the delay cancels the timer. The chatbot prototype reads `autostart=1` and auto-runs its splash demo. When a demo animation finishes, the iframe posts `dante-prototype-demo-complete` and a centered circular **Replay** icon button appears over the iframe; clicking it sends `dante-prototype-replay` to restart without reloading the iframe. Under `prefers-reduced-motion: reduce`, activation JS is skipped; a static poster and link to open the prototype in a new tab is shown instead.
 
 ### Work gallery: multi-image layouts
@@ -224,6 +226,10 @@ For visual or UX work, read these before changing UI (Impeccable / agent design 
 - **[.impeccable/design.json](.impeccable/design.json)** — Machine-readable sidecar (ramps, component snippets) for live design tooling
 
 `docs/visual-design-language.md` remains the guardrail doc for frozen homepage regions and theme experiments. Re-run `/impeccable document` after major palette or component changes.
+
+### Agent tooling (tracked vs local)
+
+Keep project agent contracts on GitHub so clones and Cloud Agents share the same rules: [`.cursor/rules/`](.cursor/rules/), [`.cursor/skills/`](.cursor/skills/), and [`.impeccable/design.json`](.impeccable/design.json) (with `PRODUCT.md` / `DESIGN.md`). Do **not** commit `.impeccable/live/` or `.impeccable/critique/` — those are ephemeral session/critique output and are gitignored.
 
 ## Cursor Cloud specific instructions
 


### PR DESCRIPTION
## Summary
- Document that `.cursor/` and `.impeccable/design.json` stay on GitHub; Impeccable `live/`/`critique/` stay local
- Fix stale rules (Markdown case studies, component CSS paths, legacy atmosphere) and harden the commit skill for dirty trees
- Add a `prototype-embed` skill for in-repo Dialpad prototype sync and demo/`postMessage` conventions

## Test plan
- [ ] Skim `.cursor/rules/dante-11ty.mdc` and updated skills for accuracy vs current `src/work/` + gallery patterns
- [ ] Confirm `.impeccable/live/` and `.impeccable/critique/` remain gitignored / untracked
- [ ] No site build required (docs/agent tooling only)


Made with [Cursor](https://cursor.com)