### PR TITLE
Improve accessibility: contrast, reduced motion, and keyboard UX

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -43,4 +43,4 @@ When in doubt, choose editorial long-form over startup landing page.
 
 ## Accessibility & Inclusion
 
-Target WCAG 2.2 AA. Lean into Geist for body and metadata readability at small sizes. Maintain sufficient contrast on the Swiss light canvas with near-black text, and on dark bands (footer, homepage showcase) with light text; do not sacrifice legibility for atmosphere. Honor `prefers-reduced-motion` for any animation. Semantic HTML and keyboard-accessible navigation are non-negotiable.
+Target WCAG 2.2 AA. Lean into Geist for body and metadata readability at small sizes. Maintain sufficient contrast on the Swiss light canvas with near-black text, and on dark bands (footer, homepage showcase) with light text; do not sacrifice legibility for atmosphere. Muted text tokens must clear ~4.5:1 on both the light canvas and raised white surfaces. Honor `prefers-reduced-motion` globally (including `scroll-behavior`). Semantic HTML and keyboard-accessible navigation are non-negotiable.

--- a/docs/visual-design-language.md
+++ b/docs/visual-design-language.md
@@ -57,7 +57,7 @@ The site uses a single Swiss light theme with dark bands:
 - **Dark bands** — near-black (`#141414` / `--color-swiss-bg-dark`) for site footer (all pages) and homepage showcase.
 - **Interactive accent** — Swiss red (`#c41230` / `--color-swiss-accent`). Nav/chrome hover, focus rings, work-index title hover. Also the blog post title end-dot (documented exception to “interactive only”).
 - **Editorial accent** — deep amber (`#E9AE0F` / `--color-accent`). Homepage belief markers and pull-quote left rule only — not default link hover.
-- **Links** — prose: underline-only in near-black; chrome: lift to Swiss red on hover.
+- **Links** — prose: underline-only in near-black; chrome on the light canvas: lift to Swiss red on hover. On dark bands (footer), keep light text and use Swiss red for the underline only so hover text stays WCAG AA.
 
 No theme picker. Build all color, type, and spacing values as CSS custom properties. `html { color-scheme: light }`.
 

--- a/src/_includes/components/site-footer.njk
+++ b/src/_includes/components/site-footer.njk
@@ -41,26 +41,46 @@
     <p class="site-footer__statement">
       Creating work cool enough to show
       <span class="site-footer__tooltip-host">
-        <button type="button" class="site-footer__reveal">
+        <button
+          type="button"
+          class="site-footer__reveal"
+          aria-describedby="site-footer-tooltip-friends"
+        >
           <span class="site-footer__reveal__text">
             <span class="site-footer__reveal__underline" aria-hidden="true"></span>
             my friends
           </span>
         </button>
-        <span class="site-footer__tooltip" role="tooltip">
-          <img src="/assets/img/home/friends.jpg" alt="" width="640" height="480" loading="lazy">
+        <span id="site-footer-tooltip-friends" class="site-footer__tooltip" role="tooltip">
+          <img
+            src="/assets/img/home/friends.jpg"
+            alt="Ted with friends."
+            width="640"
+            height="480"
+            loading="lazy"
+          >
         </span>
       </span>
       and honest enough to show
       <span class="site-footer__tooltip-host">
-        <button type="button" class="site-footer__reveal">
+        <button
+          type="button"
+          class="site-footer__reveal"
+          aria-describedby="site-footer-tooltip-parents"
+        >
           <span class="site-footer__reveal__text">
             <span class="site-footer__reveal__underline" aria-hidden="true"></span>
             my parents
           </span>
         </button>
-        <span class="site-footer__tooltip" role="tooltip">
-          <img src="/assets/img/home/parents.jpg" alt="" width="640" height="480" loading="lazy">
+        <span id="site-footer-tooltip-parents" class="site-footer__tooltip" role="tooltip">
+          <img
+            src="/assets/img/home/parents.jpg"
+            alt="Ted with his parents."
+            width="640"
+            height="480"
+            loading="lazy"
+          >
         </span>
       </span>.
     </p>

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -12,6 +12,21 @@ html {
   scroll-behavior: smooth;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important; /* kill non-essential motion; see PRODUCT.md a11y */
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
+  }
+}
+
 html {
   color-scheme: light;
 }
@@ -277,7 +292,7 @@ a:focus-visible {
 .site-footer__link:hover {
   color: var(--footer-link-hover);
   text-decoration: underline;
-  text-decoration-color: var(--footer-link-hover);
+  text-decoration-color: var(--footer-link-hover-underline);
   text-underline-offset: var(--link-chrome-underline-offset);
   text-decoration-thickness: 2px;
 }
@@ -308,7 +323,7 @@ a:focus-visible {
   clip: auto;
   white-space: normal;
   background-color: var(--color-surface-raised);
-  color: var(--color-site-fg-muted);
+  color: var(--color-site-fg);
   border: var(--border-width-hairline) solid var(--color-border-subtle);
   font-family: var(--font-sans);
   font-size: var(--type-min-size);

--- a/src/assets/js/site-nav.js
+++ b/src/assets/js/site-nav.js
@@ -10,6 +10,22 @@
 
   /* Keep in sync with styles.css mobile nav breakpoint. */
   const overlayQuery = window.matchMedia("(max-width: 56rem)");
+  let lastFocus = null;
+
+  const getFocusable = () => {
+    const nodes = nav.querySelectorAll(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    return Array.prototype.filter.call(nodes, (el) => {
+      if (el.hasAttribute("inert") || el.getAttribute("aria-hidden") === "true") {
+        return false;
+      }
+      if (list.contains(el) && list.hasAttribute("inert")) {
+        return false;
+      }
+      return el.getClientRects().length > 0;
+    });
+  };
 
   const setListInert = (inert) => {
     if (inert) {
@@ -21,13 +37,52 @@
     }
   };
 
+  const trapFocus = (event) => {
+    if (!nav.classList.contains("is-open") || !overlayQuery.matches) {
+      return;
+    }
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    const focusable = getFocusable();
+    if (focusable.length === 0) {
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+      return;
+    }
+
+    if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
   const setOpen = (open) => {
+    const wasOpen = nav.classList.contains("is-open");
     nav.classList.toggle("is-open", open);
     toggle.setAttribute("aria-expanded", open ? "true" : "false");
     label.textContent = open ? "Close" : "Menu";
 
     /* inert only when the overlay pattern is hiding the list (mobile, closed). */
     setListInert(overlayQuery.matches && !open);
+
+    if (open && overlayQuery.matches && !wasOpen) {
+      lastFocus = document.activeElement;
+      const focusable = getFocusable();
+      const firstInList = focusable.find((el) => list.contains(el));
+      (firstInList || toggle).focus();
+    } else if (!open && wasOpen && lastFocus && typeof lastFocus.focus === "function") {
+      lastFocus.focus();
+      lastFocus = null;
+    }
   };
 
   const close = () => setOpen(false);
@@ -47,6 +102,7 @@
       toggle.setAttribute("aria-expanded", "false");
       label.textContent = "Menu";
       setListInert(false);
+      lastFocus = null;
       return;
     }
     setOpen(nav.classList.contains("is-open"));
@@ -61,9 +117,12 @@
 
   document.addEventListener("keydown", (event) => {
     if (event.key === "Escape" && nav.classList.contains("is-open")) {
+      lastFocus = null;
       close();
       toggle.focus();
+      return;
     }
+    trapFocus(event);
   });
 
   list.addEventListener("click", (event) => {

--- a/themes/theme.css
+++ b/themes/theme.css
@@ -9,6 +9,7 @@
   --color-swiss-fg-light: #141414;
   --color-swiss-bg-dark: #141414;
   --color-swiss-fg-dark: #f5f5f5;
+  /* ~5.75:1 on #141414 — AA for normal text */
   --color-swiss-fg-dark-muted: rgb(245 245 245 / 0.55);
   --color-swiss-accent: #c41230;
   --color-swiss-accent-hover: #e0183a;
@@ -18,7 +19,8 @@
   /* Semantic page canvas (Swiss light) */
   --color-site-bg: var(--color-swiss-bg-light);
   --color-site-fg: var(--color-swiss-fg-light);
-  --color-site-fg-muted: color-mix(in srgb, var(--color-swiss-fg-light) 55%, var(--color-swiss-bg-light));
+  /* ~4.97:1 on #f3f3f3 / ~5.51:1 on #fff — AA for normal text (was 55%, ~3.96:1) */
+  --color-site-fg-muted: color-mix(in srgb, var(--color-swiss-fg-light) 62%, var(--color-swiss-bg-light));
   --color-prose-body: color-mix(in srgb, var(--color-swiss-fg-light) 82%, var(--color-swiss-bg-light));
 
   /* Editorial accent — not default link hover */
@@ -73,7 +75,8 @@
   --color-figure-caption-title: var(--color-site-fg);
   --color-figure-caption-body: var(--color-site-fg-muted);
   --color-figure-rule: var(--color-border-strong);
-  --color-figure-kicker: rgb(20 20 20 / 0.32);
+  /* ~3.0:1 on light canvas — large/UI label floor */
+  --color-figure-kicker: rgb(20 20 20 / 0.46);
 
   --color-blockquote-bg: var(--color-surface-tile-muted);
 
@@ -89,9 +92,11 @@
   --color-footer-label: var(--color-swiss-fg-dark-muted);
   --color-footer-link: var(--color-swiss-fg-dark);
   --color-footer-link-muted: var(--color-swiss-fg-dark-muted);
-  --color-footer-statement: rgb(245 245 245 / 0.42);
-  --color-footer-statement-link: rgb(245 245 245 / 0.42);
-  --color-footer-reveal-underline: rgb(245 245 245 / 0.28);
+  /* Match dark muted (~5.75:1); statement is large type but reveal words are interactive */
+  --color-footer-statement: var(--color-swiss-fg-dark-muted);
+  --color-footer-statement-link: var(--color-swiss-fg-dark-muted);
+  /* ~3.6:1 on dark band — non-text UI (1.4.11) for reveal underline */
+  --color-footer-reveal-underline: rgb(245 245 245 / 0.4);
   --footer-reveal-sketch-height: clamp(3px, 0.09em, 4px);
   --footer-reveal-text-halo: 2px;
   --footer-reveal-underline-tilt-a: 1deg;
@@ -100,5 +105,10 @@
   --color-footer-panel-border: var(--color-swiss-hairline-dark);
   --color-footer-mark: var(--color-swiss-fg-dark);
   --color-footer-tooltip-shadow: rgb(0 0 0 / 0.45);
-  --footer-link-hover: var(--color-swiss-accent);
+  /*
+   * Dark-band link hover: keep light text (Swiss red on #141414 is ~3.05:1 — fails
+   * normal-text AA). Accent is reserved for underline / focus chrome (UI 3:1 OK).
+   */
+  --footer-link-hover: var(--color-swiss-fg-dark);
+  --footer-link-hover-underline: var(--color-swiss-accent);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the still-relevant gaps from [#52](https://github.com/TedGoas/Dante/issues/52) against the site’s WCAG 2.2 AA target in `PRODUCT.md`. Most of that 2016 checklist is already covered by the current build; this PR implements the parts that still matter.

## Summary
- Raise muted and footer text tokens so normal text clears AA contrast on light and dark bands
- Keep Swiss red as chrome on dark-band link hover (underline only) so hover text stays readable
- Honor `prefers-reduced-motion` globally, including smooth scrolling
- Trap focus in the mobile nav overlay and restore it on Escape
- Wire footer photo reveals with `aria-describedby` and descriptive `alt` text

## Test plan
- [x] `npm run build`
- [x] Footer “my friends” / “my parents” tooltips on hover/focus
- [x] Footer link hover: light text + Swiss-red underline (not red text)
- [x] Mobile nav (~390px): open menu, links visible

[Footer friends tooltip](https://cursor.com/agents/bc-85221d07-4704-4ab8-9d56-7586876a6440/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffooter-friends-tooltip.webp)
[Footer parents tooltip](https://cursor.com/agents/bc-85221d07-4704-4ab8-9d56-7586876a6440/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffooter-parents-tooltip.webp)
[Footer link hover red underline](https://cursor.com/agents/bc-85221d07-4704-4ab8-9d56-7586876a6440/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffooter-link-hover.webp)
[Mobile nav open](https://cursor.com/agents/bc-85221d07-4704-4ab8-9d56-7586876a6440/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmobile-nav-open.webp)

## Out of scope
Items from #52 that no longer hold as hard requirements (Open Color, ban italics, 2018 `:focus-visible` polyfill).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85221d07-4704-4ab8-9d56-7586876a6440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85221d07-4704-4ab8-9d56-7586876a6440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

