### PR TITLE
a11y(css): polish transitions and will-change

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -761,6 +761,7 @@ hr {
   visibility: hidden;
   pointer-events: none;
   transform: translateX(-50%) translateY(0.25rem);
+  will-change: transform;
   transition:
     opacity 0.15s ease,
     visibility 0.15s ease,
@@ -786,6 +787,7 @@ hr {
   .site-footer__tooltip {
     transition: none;
     transform: translateX(-50%);
+    will-change: auto;
   }
 
   .site-footer__tooltip-host:hover .site-footer__tooltip,
@@ -854,6 +856,7 @@ hr {
   @media (prefers-reduced-motion: reduce) {
     .site-footer__tooltip {
       transform: none;
+      will-change: auto;
     }
 
     .site-footer__tooltip-host:hover .site-footer__tooltip,
@@ -983,6 +986,7 @@ hr {
   background-color: currentColor;
   border-radius: 1px;
   transform-origin: 50% 50%;
+  will-change: transform;
   transition:
     transform var(--site-nav-duration-toggle) var(--site-nav-ease-out),
     opacity var(--site-nav-duration-toggle) var(--site-nav-ease-out);
@@ -1093,6 +1097,7 @@ hr {
     visibility: hidden;
     pointer-events: none;
     transform: translateY(-0.25rem) scale(0.96);
+    will-change: transform;
     transition:
       opacity var(--site-nav-duration-out) var(--site-nav-ease-out),
       transform var(--site-nav-duration-out) var(--site-nav-ease-out),
@@ -1127,6 +1132,7 @@ hr {
   .site-nav__toggle-bar,
   html.js .site-nav-list {
     transition: none;
+    will-change: auto;
   }
 }
 
@@ -1890,11 +1896,11 @@ hr {
   font-weight: 500;
   line-height: 1.4;
   color: var(--color-site-fg);
+  transition: color 160ms ease;
 }
 
 .work-index__card:hover .work-index__title {
   color: var(--color-swiss-accent);
-  transition: color 160ms ease;
 }
 
 .work-index__summary {
@@ -1906,7 +1912,7 @@ hr {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .work-index__card:hover .work-index__title {
+  .work-index__title {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary
- Move work-index title color transition onto the base rule so hover in and out both animate
- Add `will-change: transform` on nav toggle bars, mobile nav list, and footer tooltips; clear it under `prefers-reduced-motion`
- Leave the global reduced-motion kill-switch and media/prototype behavior overrides unchanged

## Test plan
- [ ] On /work, hover a card title — color eases in and out
- [ ] Toggle mobile nav — hamburger morph and menu open/close still feel smooth
- [ ] Hover/focus a footer reveal tooltip — fade/slide still works
- [ ] Enable OS reduced motion — transitions resolve immediately; tooltips do not translate; video/prototype reduced-motion fallbacks still apply
- [ ] Optional: DevTools Layers — confirm transform targets promote without obvious jank


Made with [Cursor](https://cursor.com)