### PR TITLE
fix(build): keep spaces when minifying HTML

### DIFF
--- a/lib/transforms/minifyHtml.js
+++ b/lib/transforms/minifyHtml.js
@@ -5,7 +5,11 @@ module.exports = (content, outputPath) => {
     return htmlmin.minify(content, {
       useShortDoctype: true,
       removeComments: true,
-      collapseWhitespace: true
+      collapseWhitespace: true,
+      // Keep a single space between tags/text. Without this, production
+      // builds strip spaces that local (unminified) HTML keeps — e.g. the
+      // gap between the home hero avatar and “Ted”.
+      conservativeCollapse: true
     });
   }
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -8,7 +8,7 @@ description: Product designer, researcher, and front-end developer
   <h1 id="home-heading" class="home-hero__headline">
     I'm
     <span class="hero-avatar-wrap" tabindex="0">
-      <img src="/assets/img/th-ted.jpg" alt="Ted" class="hero-avatar hero-avatar--base" width="112" height="112">
+      <img src="/assets/img/th-ted.jpg" alt="" class="hero-avatar hero-avatar--base" width="112" height="112">
       <span class="hero-avatar-cycle" aria-hidden="true">
         <img src="/assets/img/th-ted-2.jpg" alt="" class="hero-avatar hero-avatar--frame" width="112" height="112">
         <img src="/assets/img/th-ted-3.jpg" alt="" class="hero-avatar hero-avatar--frame" width="112" height="112">


### PR DESCRIPTION
## Summary
- Enable `conservativeCollapse` in production HTML minify so spaces between tags and text are preserved (matches local unminified HTML).
- Fixes the home hero avatar overlapping “Ted” on Netlify/Firefox, where aggressive whitespace collapse had removed the gap.
- Also empties the decorative hero avatar `alt` (headline already says the name).

## Test plan
- [ ] Deploy preview: avatar ↔ “Ted” spacing matches local in Firefox and Chrome
- [ ] Spot-check other inline gaps (e.g. company logos in hero copy) look unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small build-time minifier tweak and a decorative image alt change; no auth, data, or core logic impact.
> 
> **Overview**
> Production HTML minification now uses **`conservativeCollapse`** alongside **`collapseWhitespace`**, so a single space between inline tags and text is kept instead of being stripped. That aligns deployed output with local unminified HTML and fixes the home hero avatar sitting flush against **“Ted”** (notably on Netlify/Firefox).
> 
> The decorative hero avatar **`alt`** is cleared because the headline already includes the name, avoiding redundant screen reader announcements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 373679c0dee17d5e26fc199ccf90645571870b78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->