### PR TITLE
Follow up Dialpad Scorecards copy and thumb-prototype fixes

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -3208,6 +3208,8 @@ hr {
 }
 
 .thumb-prototype__frame {
+  container-type: size;
+  container-name: thumb-prototype;
   position: relative;
   width: 100%;
   aspect-ratio: var(--thumb-prototype-aspect-ratio, 470 / 400);
@@ -3257,13 +3259,20 @@ hr {
 .thumb-prototype__iframe {
   display: block;
   position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+  top: 50%;
+  left: 50%;
+  width: var(--thumb-prototype-width, 470px);
+  height: var(--thumb-prototype-height, 400px);
   border: 0;
   border-radius: 0;
   pointer-events: none;
   background-color: var(--color-surface-raised);
+  transform-origin: center center;
+  /* Cover the frame (Omnichannel uses a sibling-matched aspect that differs from the demo). */
+  transform: translate(-50%, -50%) scale(max(
+    calc(100cqw / var(--thumb-prototype-width, 470px)),
+    calc(100cqh / var(--thumb-prototype-height, 400px))
+  ));
 }
 
 .thumb-prototype__fallback {
@@ -3272,7 +3281,7 @@ hr {
 
 @media (prefers-reduced-motion: reduce) {
   .thumb-prototype__cue {
-    transition: none;
+    display: none;
   }
 
   .thumb-prototype__fallback {

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -3268,10 +3268,13 @@ hr {
   pointer-events: none;
   background-color: var(--color-surface-raised);
   transform-origin: center center;
-  /* Cover the frame (Omnichannel uses a sibling-matched aspect that differs from the demo). */
+  /*
+   * Cover the frame. tan(atan2(a, b)) yields a unitless a/b so Firefox accepts
+   * the scale() (plain length/length division is invalid there).
+   */
   transform: translate(-50%, -50%) scale(max(
-    calc(100cqw / var(--thumb-prototype-width, 470px)),
-    calc(100cqh / var(--thumb-prototype-height, 400px))
+    tan(atan2(100cqw, var(--thumb-prototype-width, 470px))),
+    tan(atan2(100cqh, var(--thumb-prototype-height, 400px)))
   ));
 }
 

--- a/src/assets/js/thumb-prototype.js
+++ b/src/assets/js/thumb-prototype.js
@@ -23,41 +23,43 @@ function preloadThumb(root) {
   iframe.src = source;
 }
 
-function activateThumb(root) {
+function initThumbPrototype(root) {
+  let active = false;
+  let pendingPlayHandler = null;
   const iframe = root.querySelector('.thumb-prototype__iframe');
 
-  if (!iframe) {
-    return;
-  }
+  const clearPendingPlay = () => {
+    if (pendingPlayHandler && iframe) {
+      iframe.removeEventListener('load', pendingPlayHandler);
+      pendingPlayHandler = null;
+    }
+  };
 
-  const play = () => {
+  const playIfActive = () => {
+    pendingPlayHandler = null;
+
+    if (!active) {
+      return;
+    }
+
     postToIframe(root, 'dante-thumb-prototype-play');
   };
 
-  if (!iframe.getAttribute('src')) {
-    iframe.addEventListener('load', play, { once: true });
-    preloadThumb(root);
-  } else if (iframe.contentDocument?.readyState === 'complete' || iframe.dataset.ready === '1') {
-    play();
-  } else {
-    iframe.addEventListener('load', play, { once: true });
-  }
+  const schedulePlay = () => {
+    clearPendingPlay();
 
-  root.classList.add('is-active');
-}
+    if (!iframe) {
+      return;
+    }
 
-function deactivateThumb(root) {
-  if (!root.classList.contains('is-active')) {
-    return;
-  }
+    if (iframe.dataset.ready === '1' || iframe.contentDocument?.readyState === 'complete') {
+      playIfActive();
+      return;
+    }
 
-  postToIframe(root, 'dante-thumb-prototype-reset');
-  root.classList.remove('is-active');
-}
-
-function initThumbPrototype(root) {
-  let active = false;
-  const iframe = root.querySelector('.thumb-prototype__iframe');
+    pendingPlayHandler = playIfActive;
+    iframe.addEventListener('load', pendingPlayHandler, { once: true });
+  };
 
   if (iframe) {
     iframe.addEventListener('load', () => {
@@ -73,7 +75,8 @@ function initThumbPrototype(root) {
     }
 
     active = true;
-    activateThumb(root);
+    root.classList.add('is-active');
+    schedulePlay();
   };
 
   const stop = () => {
@@ -82,7 +85,9 @@ function initThumbPrototype(root) {
     }
 
     active = false;
-    deactivateThumb(root);
+    clearPendingPlay();
+    postToIframe(root, 'dante-thumb-prototype-reset');
+    root.classList.remove('is-active');
   };
 
   root.addEventListener('pointerenter', start);

--- a/src/work/2021-01-01-dialpad.md
+++ b/src/work/2021-01-01-dialpad.md
@@ -41,19 +41,19 @@ Some highlights: helping grow the support product from $50M to $300M ARR, shapin
   </figure>
   <figure class="work-gallery__item">
     <figcaption class="work-gallery__caption">QA at scale</figcaption>
-    <p class="work-gallery__description">Monitoring a contact center is a big job. Even a small one can log hundreds of calls a day.</p>
+    <p class="work-gallery__description">Monitoring a contact center is a big job. Even a small one can log hundreds of calls a day. Scorecards is how supervisors evaluate that volume without grading everything by hand.</p>
     {% prototypeEmbed "scorecards", "Dialpad IC scorecards summary design.", 1440, 900 %}
-    <p class="work-gallery__followup">I designed Scorecards to help supervisors evaluate conversations, spot patterns, and coach their teams without drowning in the volume. The summary view surfaces what matters first, so quality review scales with the queue instead of competing with it.</p>
+    <p class="work-gallery__followup">I grew Scorecards from a manual QA tool into an AI grading platform. Before automation, only about 2% to 3% of conversations got scored, which is nowhere near a real picture of the floor. We spent as much energy on trust as on the model: show the evidence, let humans override, and warn when language is too fuzzy. Visualizations mattered too, because contact center work runs on metrics, including digests that land in the inbox. Adoption skewed toward the bigger seats, which matched who needed coverage the most.</p>
     <div class="work-gallery__thumbs work-gallery__thumbs--halves">
       <figure class="work-gallery__thumb">
         <div class="work-gallery__thumb-media work-gallery__thumb-media--inset work-gallery__thumb-media--inset-card">
           <img src="/assets/img/dialpad/th-scorecards-unclear-term.svg" alt="Scorecards unclear term warning." loading="lazy">
         </div>
-        <figcaption class="work-gallery__thumb-caption">Unclear term</figcaption>
+        <figcaption class="work-gallery__thumb-caption">When AI hits jargon it does not know, it asks for a definition instead of inventing one.</figcaption>
       </figure>
       <figure class="work-gallery__thumb">
         <img src="/assets/img/dialpad/th-email-digest-mobile.svg" alt="Scorecards weekly report." loading="lazy">
-        <figcaption class="work-gallery__thumb-caption">Weekly report</figcaption>
+        <figcaption class="work-gallery__thumb-caption">A mobile weekly report that puts QA metrics in the inbox, not only in the app.</figcaption>
       </figure>
     </div>
   </figure>


### PR DESCRIPTION
## Summary
- Expand Scorecards gallery copy (intro, follow-up, and thumb captions) for the Dialpad IC case study.
- Harden thumb-prototype hover play so pending load handlers do not fire after leave, scale the iframe to cover the frame, and hide the Hover me cue under reduced motion.

## Test plan
- [ ] Open `/work/dialpad/` and confirm Scorecards copy reads correctly.
- [ ] Hover the Omnichannel quick-reply thumb: demo plays, fills the frame (no side letterboxing), cue fades.
- [ ] Hover then leave before the iframe finishes loading: demo should not start after leave.
- [ ] With `prefers-reduced-motion: reduce`, confirm Hover me cue is hidden and the open-in-new-tab fallback still works.


Made with [Cursor](https://cursor.com)