### PR TITLE
style(workos): polish — consistent 4px border radius

### DIFF
--- a/workos/src/components/CreatableCombobox.tsx
+++ b/workos/src/components/CreatableCombobox.tsx
@@ -83,7 +83,7 @@ export function CreatableCombobox({
             aria-invalid={error ? true : undefined}
             aria-describedby={error ? errorId : undefined}
             className={cn(
-              'h-10 w-full justify-between rounded-none font-normal normal-case tracking-normal',
+              'h-10 w-full justify-between rounded-md font-normal normal-case tracking-normal',
               error && 'border-nyse-fail hover:bg-background'
             )}
           >

--- a/workos/src/components/SampleDropzone.tsx
+++ b/workos/src/components/SampleDropzone.tsx
@@ -54,7 +54,7 @@ export function SampleDropzone(props: SampleDropzoneProps) {
       >
         <div
           className={cn(
-            'flex w-full flex-col rounded-none border border-dashed border-nyse-border bg-dropzone-surface px-4 text-center',
+            'flex w-full flex-col rounded-md border border-dashed border-nyse-border bg-dropzone-surface px-4 text-center',
             fill ? 'min-h-64 flex-1 py-6' : 'py-8'
           )}
         >
@@ -146,7 +146,7 @@ function UploadDropzone({
       <button
         type="button"
         className={cn(
-          'flex w-full flex-col items-center justify-center gap-2 rounded-none border border-dashed border-nyse-border bg-dropzone-surface px-4 text-center transition-colors',
+          'flex w-full flex-col items-center justify-center gap-2 rounded-md border border-dashed border-nyse-border bg-dropzone-surface px-4 text-center transition-colors',
           fill ? 'min-h-64 flex-1 py-10' : 'py-8',
           dragging && 'border-ice-blue bg-accent'
         )}
@@ -182,7 +182,7 @@ function UploadDropzone({
           {files.map((file) => (
             <li
               key={file.id}
-              className="flex items-center gap-2 rounded-none border border-border bg-background px-3 py-2"
+              className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2"
             >
               <FileJson className="size-4 text-ice-blue" aria-hidden="true" />
               <a

--- a/workos/src/components/TextField.tsx
+++ b/workos/src/components/TextField.tsx
@@ -36,7 +36,7 @@ export function TextField({
         aria-describedby={error ? errorId : undefined}
         onChange={(event) => onChange(event.target.value)}
         className={cn(
-          'h-10 w-full rounded-none border border-border bg-background px-3 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring',
+          'h-10 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring',
           error && 'border-nyse-fail'
         )}
       />

--- a/workos/src/components/ui/badge.tsx
+++ b/workos/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'inline-flex items-center gap-1.5 rounded-none border-0 px-0 py-0 text-xs font-semibold uppercase tracking-wide',
+  'inline-flex items-center gap-1.5 rounded-md border-0 px-0 py-0 text-xs font-semibold uppercase tracking-wide',
   {
     variants: {
       variant: {

--- a/workos/src/components/ui/button.tsx
+++ b/workos/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-none text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+  'inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/workos/src/components/ui/command.tsx
+++ b/workos/src/components/ui/command.tsx
@@ -12,7 +12,7 @@ function Command({
     <CommandPrimitive
       data-slot="command"
       className={cn(
-        'flex h-full w-full flex-col overflow-hidden rounded-none bg-popover text-popover-foreground',
+        'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
         className
       )}
       {...props}

--- a/workos/src/components/ui/popover.tsx
+++ b/workos/src/components/ui/popover.tsx
@@ -28,7 +28,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 w-[var(--radix-popover-trigger-width)] rounded-none border border-border bg-popover p-0 text-popover-foreground shadow-sm outline-none',
+          'z-50 w-[var(--radix-popover-trigger-width)] rounded-md border border-border bg-popover p-0 text-popover-foreground shadow-sm outline-none',
           className
         )}
         {...props}

--- a/workos/src/index.css
+++ b/workos/src/index.css
@@ -34,21 +34,21 @@
   --color-popover-foreground: #1a1a1a;
   --color-card: #ffffff;
   --color-card-foreground: #1a1a1a;
-  --radius-sm: 0px;
-  --radius-md: 0px;
-  --radius-lg: 0px;
-  --radius-status: 0.375rem;
+  --radius-sm: 4px;
+  --radius-md: 4px;
+  --radius-lg: 4px;
+  --radius-status: 4px;
   --color-status-ok-bg: #e8f5ec;
   --color-status-ok-fg: #1f7a45;
   --color-status-fail-bg: #fceeed;
   --color-status-fail-fg: #c9372c;
   --color-dropzone-surface: #fafafa;
   --spacing-workos: 2.5rem;
-  --radius-table: 8px;
+  --radius-table: 4px;
   --page-title-accent-height: 4px;
   --color-page-title-accent: color-mix(in srgb, var(--color-ice-blue) 45%, white);
   --drawer-width: 24rem;
-  --radius-assistant-bubble: 0.75rem;
+  --radius-assistant-bubble: 4px;
 }
 
 @layer base {
@@ -260,7 +260,7 @@
 }
 
 .mapping-assistant__action-btn {
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 
@@ -274,7 +274,7 @@
   width: 100%;
   height: 2.5rem;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: var(--color-background);
   padding: 0 0.75rem;
   font: inherit;

--- a/workos/src/themes.css
+++ b/workos/src/themes.css
@@ -31,10 +31,10 @@
   --color-popover-foreground: #1a1a1a;
   --color-card: #ffffff;
   --color-card-foreground: #1a1a1a;
-  --radius-sm: 0px;
-  --radius-md: 0px;
-  --radius-lg: 0px;
-  --radius-status: 0.375rem;
+  --radius-sm: 4px;
+  --radius-md: 4px;
+  --radius-lg: 4px;
+  --radius-status: 4px;
   --color-status-ok-bg: #e8f5ec;
   --color-status-ok-fg: #1f7a45;
   --color-status-fail-bg: #fceeed;


### PR DESCRIPTION
## Summary

- Unify WorkOS border radius to **4px** across inputs, buttons, comboboxes, popovers, dropzones, badges/status chips, the results table, and the mapping assistant
- Drive corners from shared radius tokens (`--radius-sm/md/lg`, `--radius-table`, etc.) so future polish stays consistent

Catch-all polish PR — more WorkOS visual tweaks can land here.

## Test plan

- [ ] Open `http://localhost:5173/workos/`
- [ ] Confirm Name input, mapping comboboxes, Rerun test, and table frame share the same 4px corners
- [ ] Open a combobox — popover/menu matches
- [ ] Open mapping assistant — Yes/No buttons and Message field match


Made with [Cursor](https://cursor.com)