### PR TITLE
fix(workos): stabilize validation table height and column widths

### DIFF
--- a/workos/src/components/StatusIcon.tsx
+++ b/workos/src/components/StatusIcon.tsx
@@ -43,24 +43,27 @@ export function FieldStatusCell({
     </>
   )
 
+  const valueClassName = cn(
+    'border-b border-dotted leading-none',
+    onValueClick
+      ? 'cursor-pointer border-foreground/45 p-0 text-left hover:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1'
+      : 'border-transparent'
+  )
+
   return (
     <span
       className={cn(
-        'inline-flex items-center gap-2 text-sm font-normal text-foreground',
+        'flex h-5 items-center gap-2 text-sm font-normal leading-none text-foreground',
         className
       )}
     >
       <CellBadge status={cell.status} />
       {onValueClick ? (
-        <button
-          type="button"
-          onClick={onValueClick}
-          className="cursor-pointer border-b border-dotted border-foreground/45 text-left hover:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-        >
+        <button type="button" onClick={onValueClick} className={valueClassName}>
           {displayValue}
         </button>
       ) : (
-        <span>{displayValue}</span>
+        <span className={valueClassName}>{displayValue}</span>
       )}
     </span>
   )

--- a/workos/src/components/ValidationTable.tsx
+++ b/workos/src/components/ValidationTable.tsx
@@ -74,6 +74,12 @@ export function ValidationTable({
           </div>
         ) : (
           <Table>
+            <colgroup>
+              <col className="w-1/4" />
+              <col className="w-1/4" />
+              <col className="w-1/4" />
+              <col className="w-1/4" />
+            </colgroup>
             <TableHeader>
               <TableRow className="hover:bg-transparent">
                 <TableHead>Ticker</TableHead>

--- a/workos/src/components/ValidationTable.tsx
+++ b/workos/src/components/ValidationTable.tsx
@@ -29,9 +29,11 @@ function ValidationTableSkeleton() {
           {Array.from({ length: 4 }, (__, cellIndex) => (
             <TableCell key={cellIndex}>
               <span
-                className="validation-table__skeleton-bar"
+                className="flex h-5 items-center"
                 aria-hidden="true"
-              />
+              >
+                <span className="validation-table__skeleton-bar" />
+              </span>
             </TableCell>
           ))}
         </TableRow>

--- a/workos/src/index.css
+++ b/workos/src/index.css
@@ -153,8 +153,9 @@
 /* Validation table skeleton loader */
 .validation-table__skeleton-bar {
   display: block;
+  width: 5rem;
   height: 0.875rem;
-  max-width: 5rem;
+  max-width: 100%;
   border-radius: 2px;
   background: color-mix(in srgb, var(--color-muted-foreground) 18%, var(--color-muted));
   animation: validation-table-skeleton-pulse 1.4s ease-in-out infinite;

--- a/workos/src/themes.css
+++ b/workos/src/themes.css
@@ -49,6 +49,10 @@
   border: 1px solid var(--color-table-border);
 }
 
+.validation-table__frame [data-slot='table'] {
+  table-layout: fixed;
+}
+
 .validation-table__frame [data-slot='table-head'] {
   height: auto;
   padding: 0.875rem 1.25rem;


### PR DESCRIPTION
## Summary

Follow-up to #213. These commits were made on the polish branch locally but never pushed before that PR merged, so they did not ship.

- Keep row height stable across fail / skeleton / pass (reserved null underline, shared `h-5` cell shells, explicit skeleton bar width)
- Lock column widths with `table-layout: fixed` and equal `colgroup` so the table does not shift when switching to the skeleton loader

## Test plan

- [ ] Open `http://localhost:5173/workos/` (or the deploy preview)
- [ ] Fail → Rerun (skeleton) → pass → Reset — table frame height and column edges should not jump
- [ ] Confirm skeleton bars are still visible during rerun


Made with [Cursor](https://cursor.com)