### PR TITLE
chore(agents): collaboration norms

### DIFF
--- a/.cursor/rules/dante-11ty.mdc
+++ b/.cursor/rules/dante-11ty.mdc
@@ -17,7 +17,9 @@ alwaysApply: true
 
 - Exploratory UI: short plan or 2 options → wait for pick → implement one; temporary variant pickers are throwaway
 - Polish turns: change one visual variable, then stop for review
-- After UI edits: give the URL; if changes “aren’t visible,” stop and verify (server, URL, branch, cache) before more edits; ask local vs Netlify early on deploy-only bugs
+- Ambiguous or repeated ask: restate (“I’ll change X on `/path/`”) or ask one clarifier; a re-ask means you missed — confirm, then act (don’t silently redo the same edit)
+- After UI edits: verify the change is in the intended **source** file (not `dist/`), give the exact URL; don’t say “hard refresh” until source is confirmed; use a browser check when available
+- “I still see…” / no visible change: stop design work; diagnose delivery (file, selector, page, server/port, branch, local vs Netlify) before more tweaks
 - After two failed approaches: name the pivot (“abandon A; port B”) — do not invent a third custom path
 - Dirty tree / other agents: surface collisions; commit only this task’s paths
 

--- a/.cursor/rules/dante-11ty.mdc
+++ b/.cursor/rules/dante-11ty.mdc
@@ -7,10 +7,19 @@ alwaysApply: true
 
 ## General
 
-- This is a native HTML and CSS project using 11ty. Do not introduce Tailwind, Bootstrap, or any CSS framework
+- This is a native HTML and CSS project using 11ty. Do not introduce Tailwind, Bootstrap, React, or any CSS/JS framework (no take-home app scaffolds unless Ted explicitly carves that out)
 - Do not add npm packages without asking first and explaining why they're needed
 - Do not generate content — no placeholder text, fake names, or dummy data
 - Always consider page load performance in every suggestion
+- Prefer existing project skills (gallery embeds, thumbs, figures, case-study copy, optimize-images, ted-voice, commit/push) over re-explaining those patterns — see `.cursor/skills/` and AGENTS.md *Working with agents*
+
+## Working with Ted (visual / iterative work)
+
+- Exploratory UI: short plan or 2 options → wait for pick → implement one; temporary variant pickers are throwaway
+- Polish turns: change one visual variable, then stop for review
+- After UI edits: give the URL; if changes “aren’t visible,” stop and verify (server, URL, branch, cache) before more edits; ask local vs Netlify early on deploy-only bugs
+- After two failed approaches: name the pivot (“abandon A; port B”) — do not invent a third custom path
+- Dirty tree / other agents: surface collisions; commit only this task’s paths
 
 ## CSS
 

--- a/.cursor/skills/commit/SKILL.md
+++ b/.cursor/skills/commit/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Proposes a title-only Conventional Commit subject, then runs git status/diff,
   stages changes, and git commit -m. Use when the user asks for a commit message,
   to stage and commit, or to save work locally — not when they only want to push.
+  Also use when they ask whether work was already committed: check git status first;
+  do not commit unless they explicitly ask to.
 ---
 
 # Commit
@@ -37,11 +39,12 @@ description: >-
 
 ## Workflow
 
-1. **Review** — `git status`; `git diff` (staged and unstaged) so the message matches what will be committed.
-2. **Dirty tree** — List every modified/untracked path. Separate **this task** from leftovers (other agents, WIP, unrelated experiments).
-3. **Stage selectively** — `git add <paths>` or `git add -p` for **only** the task paths. Never `git add -A` / `git add .` when unrelated changes exist.
-4. **Refuse scooping** — If unrelated dirty files are present, leave them unstaged. If the user asked to “commit everything,” confirm first. If unsure which paths belong to the task, ask before staging.
-5. **Commit** — `git commit -m "type(scope): description"`.
+1. **Status check first** — If the user asks “did we commit?” / “is this committed?” / similar, run `git status` (and `git log -1` if useful) and answer from that. Do **not** create a new commit unless they explicitly ask to commit.
+2. **Review** — `git status`; `git diff` (staged and unstaged) so the message matches what will be committed.
+3. **Dirty tree** — List every modified/untracked path. Separate **this task** from leftovers (other agents, WIP, unrelated experiments).
+4. **Stage selectively** — `git add <paths>` or `git add -p` for **only** the task paths. Never `git add -A` / `git add .` when unrelated changes exist.
+5. **Refuse scooping** — If unrelated dirty files are present, leave them unstaged. If the user asked to “commit everything,” confirm first. If unsure which paths belong to the task, ask before staging.
+6. **Commit** — `git commit -m "type(scope): description"`.
 
 Do **not** run `git push` here. If the user wants to publish, use the **push** skill after committing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,7 +348,9 @@ Collaboration norms so agents match how this site is actually built (visual crit
 
 - **Plan, then one option** — For visual or exploratory UI, prefer a short plan or 2 concrete options, wait for a pick, then implement **one**. Do not productize temporary “pick a variant” chrome.
 - **One visual variable per polish turn** — When refining (spacing, radius, dash pattern, color), change one thing and stop for eyes-on review.
-- **Verify before the next edit** — After a UI change, state the URL and that a hard refresh may be needed. If Ted says he doesn’t see the change, **stop and verify** (dev server, correct branch/URL, cache) before more edits. For deploy-only bugs, ask **local vs Netlify** early.
+- **Confirm the ask when fuzzy or repeated** — If the request is ambiguous, restate in one line (“I’ll change X on `/work/…`”) or ask one clarifying question before editing. If Ted asks again or rephrases the same thing, treat that as a miss: re-read the ask, confirm understanding, then act — do not silently redo the same edit.
+- **Prove the change landed, then invite refresh** — After CSS/markup edits: confirm the intended **source** file (never `dist/`) actually contains the change; give the exact local URL. Do not blame cache or say “hard refresh” until the source change is verified. When a browser tool is available, check the live page before claiming the fix.
+- **“I still see…” = stop and diagnose** — No more design tweaks until delivery is ruled out: wrong file/selector/page, dead or wrong-port dev server, wrong branch, or Netlify vs local. For deploy-only bugs, ask **local vs Netlify** early.
 - **Pivot after two fails** — If an approach fails twice, name the abandon/pivot (“abandon A; port B”) instead of inventing a third custom path.
 - **Prefer existing skills** — Gallery embeds, thumbs, figure layouts, case-study copy, image optimize, voice, commit/push: invoke the skill (or point to it) instead of re-explaining the pattern. See [`.cursor/skills/`](.cursor/skills/).
 - **This repo’s stack only** — Native HTML/CSS/11ty/vanilla JS. No Tailwind, React, or take-home app scaffolds here unless Ted explicitly carves that out.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,6 +342,18 @@ Each palette sets `--work-gallery-atmosphere-*` custom properties (base, glow-a,
 - Discuss implementation approaches before coding
 - Get approval for any new dependencies or major changes
 
+### Working with agents
+
+Collaboration norms so agents match how this site is actually built (visual critique loops, skills, selective commits):
+
+- **Plan, then one option** — For visual or exploratory UI, prefer a short plan or 2 concrete options, wait for a pick, then implement **one**. Do not productize temporary “pick a variant” chrome.
+- **One visual variable per polish turn** — When refining (spacing, radius, dash pattern, color), change one thing and stop for eyes-on review.
+- **Verify before the next edit** — After a UI change, state the URL and that a hard refresh may be needed. If Ted says he doesn’t see the change, **stop and verify** (dev server, correct branch/URL, cache) before more edits. For deploy-only bugs, ask **local vs Netlify** early.
+- **Pivot after two fails** — If an approach fails twice, name the abandon/pivot (“abandon A; port B”) instead of inventing a third custom path.
+- **Prefer existing skills** — Gallery embeds, thumbs, figure layouts, case-study copy, image optimize, voice, commit/push: invoke the skill (or point to it) instead of re-explaining the pattern. See [`.cursor/skills/`](.cursor/skills/).
+- **This repo’s stack only** — Native HTML/CSS/11ty/vanilla JS. No Tailwind, React, or take-home app scaffolds here unless Ted explicitly carves that out.
+- **Dirty trees and other agents** — Surface path/branch collisions when the tree isn’t clean. Commit only this task’s paths (see **commit** skill). When another chat moved files, open with the new paths/branch.
+
 ## Design Context
 
 For visual or UX work, read these before changing UI (Impeccable / agent design flows):


### PR DESCRIPTION
## Summary
- Add *Working with agents* norms to `AGENTS.md` (plan → one option, verify before next edit, pivot after two fails, prefer skills, Dante stack only).
- Mirror the same guidance in always-on Cursor rules.
- Teach the commit skill to answer “did we commit?” from `git status` without creating a new commit.

## Test plan
- [ ] Skim AGENTS.md §6 and `.cursor/rules/dante-11ty.mdc` for tone/accuracy
- [ ] Start a fresh agent chat and confirm rules appear in context
- [ ] Ask “did we commit?” in a dirty tree and confirm status-only reply


Made with [Cursor](https://cursor.com)